### PR TITLE
fix(table): empty state wasn't showing the loading state

### DIFF
--- a/src/_designSystem/table/table.jsx
+++ b/src/_designSystem/table/table.jsx
@@ -1,9 +1,8 @@
-import {LoadingIndicator} from "../../components/loadingIndicator/loadingIndicator.jsx";
+import {TableBody} from "./tableBody.jsx";
 
 import './table.scss'
 
-export const Table = ({ meta: { caption, columns }, data, isLoading }) => {
-  if (data.length === 0) return null
+export const Table = ({meta: {caption, columns}, data, isLoading}) => {
   return (
     <table className="Table">
       <caption>{caption}</caption>
@@ -14,20 +13,7 @@ export const Table = ({ meta: { caption, columns }, data, isLoading }) => {
         ))}
       </tr>
       </thead>
-      {!isLoading
-        ? <tbody>
-        {data.map((row) => (
-          <tr key={row.title}>
-            {columns.map(({key, transformer}) => (
-              <td key={row[key]}>{transformer ? transformer(row[key]) : row[key]}</td>
-            ))}
-          </tr>
-        ))}
-        </tbody>
-        : <div className="Table-body--loading">
-          <LoadingIndicator isLoading={isLoading}/>
-        </div>
-      }
+      <TableBody isLoading={isLoading} columns={columns} data={data}/>
     </table>
   )
 }

--- a/src/_designSystem/table/table.jsx
+++ b/src/_designSystem/table/table.jsx
@@ -4,7 +4,7 @@ import './table.scss'
 
 export const Table = ({meta: {caption, columns}, data, isLoading}) => {
   return (
-    <table className="Table">
+    <table className="Table" style={{ '--columns-length': columns.length }}>
       <caption>{caption}</caption>
       <thead>
       <tr>

--- a/src/_designSystem/table/table.scss
+++ b/src/_designSystem/table/table.scss
@@ -4,6 +4,7 @@
   display: block;
   height: calc(138px * 4 + 56.5px);
   overflow: scroll;
+  width: calc(230px * 4);
 
   &:focus {
     outline: none;
@@ -47,11 +48,16 @@
     }
   }
 
-  .Table-body--loading {
-    align-items: center;
-    display: flex;
-    justify-content: center;
-    height: calc(100% - 56.5px);
-    width: 100%;
+  .Table-body {
+    &--loading, &--empty {
+      align-items: center;
+      color: #9E9E9E;
+      display: flex;
+      font-size: 0.815rem;
+      justify-content: center;
+      height: calc(100% - 56.5px);
+      width: 100%;
+    }
   }
+
 }

--- a/src/_designSystem/table/table.scss
+++ b/src/_designSystem/table/table.scss
@@ -4,7 +4,7 @@
   display: block;
   height: calc(138px * 4 + 56.5px);
   overflow: scroll;
-  width: calc(230px * 4);
+  width: calc(230px * var(--columns-length));
 
   &:focus {
     outline: none;

--- a/src/_designSystem/table/tableBody.jsx
+++ b/src/_designSystem/table/tableBody.jsx
@@ -1,0 +1,27 @@
+import {LoadingIndicator} from "../../components/loadingIndicator/loadingIndicator.jsx";
+
+export const TableBody = ({ columns, data, isLoading }) => {
+  if (isLoading) return (
+    <div className="Table-body--loading">
+      <LoadingIndicator isLoading={isLoading}/>
+    </div>
+  )
+
+  if (data.length === 0) return (
+    <div className="Table-body--empty">
+      No data available
+    </div>
+  )
+
+  return (
+    <tbody>
+    {data.map((row) => (
+      <tr key={row.title}>
+        {columns.map(({key, transformer}) => (
+          <td key={row[key]}>{transformer ? transformer(row[key]) : row[key]}</td>
+        ))}
+      </tr>
+    ))}
+    </tbody>
+  )
+}


### PR DESCRIPTION
## 🎯 Goal

On the first loading, the `table` isn't showing because `data` prop is empty. As a result, we don't see that data are loading

Another small fix in this PR related to table length

## 🧠 Approach

We create a `TableBody` component that will embed all the state logic (loading, empty, etc)

## 🧪 Test
To test this PR: 
- `git checkout fix/empty-table`
- `npm install`
- `npm run dev`

You will have the application running on `http://localhost:5173/`
