### PR TITLE
fix(ux): keyboard nav & responsive layout

### DIFF
--- a/src/_designSystem/searchSelect/searchSelect.jsx
+++ b/src/_designSystem/searchSelect/searchSelect.jsx
@@ -71,7 +71,7 @@ export const SearchSelect = ({ options, value, onChange, placeholder, label, nam
       />
       <div className="SearchSelect-input-suffix">
         {Boolean(value)
-          ? <img src={clearIcon} className="pointer" alt="clear value" width={20} height={20} onClick={() => handleClick(null)}/>
+          ? <img src={clearIcon} className="pointer" alt="clear value" tabIndex={0} width={20} height={20} onKeyUp={(e) => handleKeyUp(e, null)} onClick={() => handleClick(null)}/>
           : <img src={rightIcon} className="invisible-suffix" alt="" width={20} height={20} onClick={() => openDropDown(true)}/>
         }
       </div>

--- a/src/_designSystem/table/table.jsx
+++ b/src/_designSystem/table/table.jsx
@@ -4,16 +4,19 @@ import './table.scss'
 
 export const Table = ({meta: {caption, columns}, data, isLoading}) => {
   return (
-    <table className="Table" style={{ '--columns-length': columns.length }}>
-      <caption>{caption}</caption>
-      <thead>
-      <tr>
-        {columns.map(({header}) => (
-          <th key={header}>{header}</th>
-        ))}
-      </tr>
-      </thead>
-      <TableBody isLoading={isLoading} columns={columns} data={data}/>
-    </table>
+    <div className="Table-Container">
+      <table className="Table" style={{'--columns-length': columns.length, '--visible-rows': 4}}>
+        <caption>{caption}</caption>
+        <thead>
+        <tr>
+          {columns.map(({header}) => (
+            <th key={header}>{header}</th>
+          ))}
+        </tr>
+        </thead>
+        <TableBody isLoading={isLoading} columns={columns} data={data}/>
+      </table>
+    </div>
+
   )
 }

--- a/src/_designSystem/table/table.scss
+++ b/src/_designSystem/table/table.scss
@@ -68,8 +68,14 @@
       display: flex;
       font-size: 0.815rem;
       justify-content: center;
-      height: calc(100% - 56.5px);
       width: 100%;
+
+      td {
+        align-items: center;
+        border: none;
+        display: flex;
+        justify-content: center;
+      }
     }
   }
 

--- a/src/_designSystem/table/table.scss
+++ b/src/_designSystem/table/table.scss
@@ -1,10 +1,22 @@
+.Table-Container {
+  overflow-x: auto;
+}
+
 .Table {
   border-collapse: collapse;
   border-bottom: 1px solid #D9D9D9;
   display: block;
-  height: calc(138px * 4 + 56.5px);
-  overflow: scroll;
   width: calc(230px * var(--columns-length));
+
+  thead {
+    display: block;
+  }
+
+  tbody {
+    display: block;
+    height: calc(138px * var(--visible-rows));
+    overflow-y: scroll;
+  }
 
   &:focus {
     outline: none;
@@ -38,6 +50,7 @@
     height: 107px;
     padding: 16px;
     vertical-align: top;
+    width: 230px;
 
     &:first-child {
       font-weight: 700;

--- a/src/_designSystem/table/tableBody.jsx
+++ b/src/_designSystem/table/tableBody.jsx
@@ -2,26 +2,38 @@ import {LoadingIndicator} from "../../components/loadingIndicator/loadingIndicat
 
 export const TableBody = ({ columns, data, isLoading }) => {
   if (isLoading) return (
-    <div className="Table-body--loading">
-      <LoadingIndicator isLoading={isLoading}/>
-    </div>
+    <tbody className="Table-body--loading">
+      <tr>
+        <td>
+          <div >
+            <LoadingIndicator isLoading={isLoading}/>
+          </div>
+        </td>
+      </tr>
+    </tbody>
   )
 
   if (data.length === 0) return (
-    <div className="Table-body--empty">
-      No data available
-    </div>
+    <tbody className="Table-body--empty">
+      <tr>
+        <td>
+          <div >
+            No data available
+          </div>
+        </td>
+      </tr>
+    </tbody>
   )
 
   return (
     <tbody>
     {data.map((row) => (
-      <tr key={row.title}>
-        {columns.map(({key, transformer}) => (
-          <td key={row[key]}>{transformer ? transformer(row[key]) : row[key]}</td>
-        ))}
-      </tr>
-    ))}
+        <tr key={row.title}>
+          {columns.map(({key, transformer}) => (
+            <td key={row[key]}>{transformer ? transformer(row[key]) : row[key]}</td>
+          ))}
+        </tr>
+      ))}
     </tbody>
   )
 }


### PR DESCRIPTION
🎯 Goal

Reviewing the app before the review, I went ahead and fixed two majors issues I found: 

- We can't clear the "genre" with keyboard navigation
- The table layout isn't good enough: 
  - the DOM structure isn't valid on loading/empty state
  - the header wasn't sticky 
  - the responsive behavior wasn't working well on x axe 

🧠 Approach
To clear the "genre" option, simply add a `tabIndex=0` and call the same `handleKeyUp` I already have

To fix the table : 
- encapsulate the loading part into a `<tr><td>` 
- encapsulate the `<table>` in a `<div>` for x overflow
- apply style to `<thead>` & `<tbody>` to stick the header and get an y overflow

🧪 Test
To test this PR:

git checkout feat/improvement-ux-ui
npm install
npm run dev
You will have the application running on http://localhost:5173/